### PR TITLE
Bugfix for Safari (Privacy mode settings) (SecurityError: Dom Exception 18)

### DIFF
--- a/src/js/service/session-storage.service.js
+++ b/src/js/service/session-storage.service.js
@@ -34,10 +34,14 @@
     var prefix = $location.host().substring(0, $location.host().indexOf('.')) + '_',
       oneMinute = 60 * 1000,
       isSessionStorageAvailable = true,
-      webStorage = $window.sessionStorage,
       cache = $cacheFactory('session-cache'),
       service = this;
 
+    try {
+      var webStorage = $window.sessionStorage;
+    } catch (ex) {
+      var webStorage = false;
+    }
     /**
      * @ngdoc method
      * @name $sessionStorage.prefix


### PR DESCRIPTION
In Safari with Privacy Mode options enabled. (Safari -> Preferences -> Privacy. "Cookies and website data:" **Always block**)

This setting will cause Safari to throw SecurityError: Exception 18 while trying to import the swx-session-storage module. When this exception is thrown, the JS engine does not continue to run, which prevents the rest of the app to render to the DOM.

Wrapping the initial webStorage assignment in a try/catch, prevents the browser JS engine from crashing, which allows the rest of the javascript to execute.

(Since the use case is very specific to browser/settings, I can't write tests to cover it. it is a simple change, so it shouldn't require anything additional.)
